### PR TITLE
Update docker compose

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -21,7 +21,28 @@ services:
       PERSISTENCE_DATA_PATH: '/var/lib/weaviate'
       ENABLE_API_BASED_MODULES: 'true'
       CLUSTER_HOSTNAME: 'node1'
+
+  rabbitmq:
+    image: rabbitmq:3-management
+    container_name: rabbitmq
+    ports:
+      - '5672:5672'    # AMQP
+      - '15672:15672'  # Management UI
+    environment:
+      RABBITMQ_DEFAULT_USER: ${RABBITMQ_DEFAULT_USER:-guest}
+      RABBITMQ_DEFAULT_PASS: ${RABBITMQ_DEFAULT_PASS:-guest}
+    volumes:
+      - rabbitmq_data:/var/lib/rabbitmq
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 10s
+
 volumes:
   weaviate_data:
+  rabbitmq_data:
 ...
 


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #94


## 📝 Description

This PR introduces RabbitMQ as a first-class service in our local development Docker Compose setup. Developers can now spin up the full stack—including RabbitMQ and Weaviate—with a single:

```
docker-compose up -d
```

## 🔧 Changes Made

- Version: '3.8': Bumped Compose file format to enable healthchecks.

- Added rabbitmq service under services:

- Uses the official rabbitmq:3-management image

- Exposes AMQP (5672) and management UI (15672) ports

- Pulls credentials from environment with sensible defaults (guest/guest)

- Persists broker data in a named volume (rabbitmq_data)

- Defines a Docker healthcheck using rabbitmq-diagnostics status

- Named volume for RabbitMQ added alongside the existing weaviate_data volume

- Consistent port quoting on Weaviate service for YAML style consistency



## 📷 Screenshots or Visual Changes (if applicable)

<!-- Attach screenshots or GIFs to show visual changes, if any. -->
<!-- Drag and drop screenshots here or provide a description of visual updates. -->

<img width="1680" alt="Screenshot 2025-07-10 at 3 13 38 AM" src="https://github.com/user-attachments/assets/da664a4d-4356-4734-ad53-4f0e119861f3" />

### ✅ Checklist

- [✅] I have read the contributing guidelines.
- [✅] I have added tests that prove my fix is effective or that my feature works.
- [✅] I have added necessary documentation (if applicable).
- [✅] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added RabbitMQ as a new service in the application’s Docker setup, including a management UI and persistent storage.
  
* **Chores**
  * Updated Docker configuration to support RabbitMQ service and its associated data volume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->