### PR TITLE
docs: remove outdated --no-update flag

### DIFF
--- a/docs/INSTALL_GUIDE.md
+++ b/docs/INSTALL_GUIDE.md
@@ -33,7 +33,7 @@ poetry --version  # Should show v2.0.0 or above
 3. **Install Python dependencies**
 ```sh
 poetry env use python3.10
-poetry lock --no-update
+poetry lock 
 poetry install --with dev
 ```
 


### PR DESCRIPTION
Closes #176 


## 📝 Description

This PR updates the documentation to remove the outdated --no-update flag from the poetry lock command.
In Poetry 2.x, this flag has been removed, but the documentation still referenced it, causing the following error for users


## 🔧 Changes Made

Replaced poetry lock --no-update with poetry lock

## 📷 Screenshots or Visual Changes (if applicable)

NA

## 🤝 Collaboration

NA


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the installation guide to allow automatic lockfile updates during Python dependency resolution, enabling more flexible dependency management during setup.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->