### PR TITLE
fix: Discord startup crash by removing py-cord and correcting error handling 

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -13,7 +13,7 @@ from app.core.orchestration.agent_coordinator import AgentCoordinator
 from app.core.orchestration.queue_manager import AsyncQueueManager
 from app.database.weaviate.client import get_weaviate_client
 from integrations.discord.bot import DiscordBot
-from discord.ext import commands
+from discord import errors as discord_errors
 # DevRel commands are now loaded dynamically (commented out below)
 # from integrations.discord.cogs import DevRelCommands
 
@@ -48,7 +48,7 @@ class DevRAIApplication:
             # --- Load commands inside the async startup function ---
             try:
                 await self.discord_bot.load_extension("integrations.discord.cogs")
-            except (ImportError, commands.ExtensionError) as e:
+            except (ImportError, discord_errors.ExtensionFailed) as e:
                 logger.error("Failed to load Discord cog extension: %s", e)
 
             # Start the bot as a background task.

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -153,7 +153,6 @@ proto-plus==1.26.1
 protobuf>=3.20.2,<4.0
 ptyprocess==0.7.0
 pure_eval==0.2.3
-py-cord==2.6.2  # Latest version to minimize deprecation warnings
 pyasn1==0.6.1
 pyasn1_modules==0.4.2
 pycodestyle==2.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ requires-python = ">=3.10,<3.14"
 dependencies = [
     "supabase (>=2.13.0,<3.0.0)",
     "fastapi (>=0.115.11,<0.116.0)",
-    "py-cord (>=2.6.1,<3.0.0)",
     "pygithub (>=2.6.1,<3.0.0)",
     "slack-sdk (>=3.34.0,<4.0.0)",
     "sentence-transformers (>=3.4.1,<4.0.0)",


### PR DESCRIPTION
<!-- What issue does this PR close? -->
Closes #185 


## Description
This PR removes dependency conflicts which cause errors when starting the backend as seen in #185. 

##  Changes Made

1) Removed `py-cord` from dependency specifications which allowed `discord.py` to be imported.

2) Ensured discord.py is the sole Discord library resolved at runtime to avoid those dependency conflicts (which I think are the reason of errors in #185 )

3) Updated Discord extension error handling to use `discord.errors.ExtensionFailed` instead of `commands.ExtensionError`.


### ✅ Checklist

- [X] I have read the contributing guidelines.
- [] I have added tests that prove my fix is effective or that my feature works.
- [] I have added necessary documentation (if applicable).
- [X] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated Discord library imports and error handling mechanisms.
  * Removed unused dependency from project configuration files.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->