### PR TITLE
Fix GitHub Verification Stuck in “Pending” State (#223)

### DIFF
--- a/backend/app/services/auth/verification.py
+++ b/backend/app/services/auth/verification.py
@@ -36,6 +36,7 @@ async def create_verification_session(discord_id: str) -> Optional[str]:
     """
     supabase = get_supabase_client()
 
+    await cleanup_expired_tokens()
     _cleanup_expired_sessions()
 
     token = str(uuid.uuid4())

--- a/backend/app/services/auth/verification.py
+++ b/backend/app/services/auth/verification.py
@@ -1,5 +1,5 @@
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional, Dict, Tuple
 from app.database.supabase.client import get_supabase_client
 from app.models.database.supabase import User
@@ -16,7 +16,7 @@ def _cleanup_expired_sessions():
     """
     Remove expired verification sessions.
     """
-    current_time = datetime.now()
+    current_time = datetime.now(timezone.utc) 
     expired_sessions = [
         session_id for session_id, (discord_id, expiry_time) in _verification_sessions.items()
         if current_time > expiry_time
@@ -41,13 +41,13 @@ async def create_verification_session(discord_id: str) -> Optional[str]:
 
     token = str(uuid.uuid4())
     session_id = str(uuid.uuid4())
-    expiry_time = datetime.now() + timedelta(minutes=SESSION_EXPIRY_MINUTES)
+    expiry_time = datetime.now(timezone.utc) + timedelta(minutes=SESSION_EXPIRY_MINUTES)
 
     try:
         update_res = await supabase.table("users").update({
             "verification_token": token,
             "verification_token_expires_at": expiry_time.isoformat(),
-            "updated_at": datetime.now().isoformat()
+            "updated_at": datetime.now(timezone.utc).isoformat() 
         }).eq("discord_id", discord_id).execute()
 
         if update_res.data:
@@ -80,7 +80,7 @@ async def find_user_by_session_and_verify(
 
         discord_id, expiry_time = session_data
 
-        current_time = datetime.now().isoformat()
+        current_time = datetime.now(timezone.utc).isoformat()
         user_res = await supabase.table("users").select("*").eq(
             "discord_id", discord_id
         ).neq(
@@ -107,7 +107,7 @@ async def find_user_by_session_and_verify(
             await supabase.table("users").update({
                 "verification_token": None,
                 "verification_token_expires_at": None,
-                "updated_at": datetime.now().isoformat()
+                "updated_at": datetime.now(timezone.utc).isoformat()
             }).eq("id", user_to_verify['id']).execute()
             raise Exception(f"GitHub account {github_username} is already linked to another Discord user")
 
@@ -116,7 +116,7 @@ async def find_user_by_session_and_verify(
             "github_username": github_username,
             "email": user_to_verify.get('email') or email,
             "is_verified": True,
-            "verified_at": datetime.now().isoformat(),
+            "verified_at": datetime.now(timezone.utc).isoformat(),
             "verification_token": None,
             "verification_token_expires_at": None,
             "updated_at": datetime.now().isoformat()
@@ -140,7 +140,7 @@ async def cleanup_expired_tokens():
     Clean up expired verification tokens from database.
     """
     supabase = get_supabase_client()
-    current_time = datetime.now().isoformat()
+    current_time = datetime.now(timezone.utc).isoformat()
 
     try:
         cleanup_res = await supabase.table("users").update({
@@ -166,12 +166,12 @@ async def get_verification_session_info(session_id: str) -> Optional[Dict[str, s
 
     discord_id, expiry_time = session_data
 
-    if datetime.now() > expiry_time:
+    if datetime.now(timezone.utc) > expiry_time:
         del _verification_sessions[session_id]
         return None
 
     return {
         "discord_id": discord_id,
         "expiry_time": expiry_time.isoformat(),
-        "time_remaining": str(expiry_time - datetime.now())
+        "time_remaining": str(expiry_time - datetime.now(timezone.utc)) 
     }

--- a/backend/integrations/discord/cogs.py
+++ b/backend/integrations/discord/cogs.py
@@ -3,6 +3,7 @@ import asyncio
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
+from datetime import datetime, timezone
 
 from app.agents.devrel.onboarding.messages import (
     build_encourage_verification_message,
@@ -129,18 +130,36 @@ class DevRelCommands(commands.Cog):
                 return
 
             if user_profile.verification_token:
-                embed = discord.Embed(
-                    title="⏳ Verification Pending",
-                    description="You already have a verification in progress.",
-                    color=discord.Color.orange()
-                )
-                embed.add_field(
-                    name="What to do",
-                    value="Please complete the existing verification or wait for it to expire (5 minutes).",
-                    inline=False
-                )
-                await interaction.followup.send(embed=embed, ephemeral=True)
-                return
+                expires_at = user_profile.verification_token_expires_at
+                is_expired = False
+
+                if expires_at:
+                    if isinstance(expires_at, str):
+                        expires_at_dt = datetime.fromisoformat(expires_at)
+                    else:
+                        expires_at_dt = expires_at  
+
+                    if expires_at_dt.tzinfo is None:
+                        expires_at_dt = expires_at_dt.replace(tzinfo=timezone.utc)
+                    
+                    now_utc = datetime.now(timezone.utc)
+
+                    if expires_at_dt < now_utc:
+                        is_expired = True
+
+                if not is_expired:
+                    embed = discord.Embed(
+                        title="⏳ Verification Pending",
+                        description="You already have a verification in progress.",
+                        color=discord.Color.orange()
+                    )
+                    embed.add_field(
+                        name="What to do",
+                        value="Please complete the existing verification or wait for it to expire (5 minutes).",
+                        inline=False
+                    )
+                    await interaction.followup.send(embed=embed, ephemeral=True)
+                    return
 
             session_id = await create_verification_session(str(interaction.user.id))
             if not session_id:


### PR DESCRIPTION
Closes # 223


## 📝 Description

This PR fixes an issue where users get stuck in a “Verification Pending” state when running /verify_github, even after the verification token has expired.
The fix ensures :

- Expired verification tokens are cleaned from the database immediately
- The Discord command correctly checks token expiry before blocking re-verification

No existing verification logic or flow has been changed — only missing safety checks were added.

## 🔧 Changes Made

CHANGE 1 : Force DB cleanup before creating a verification session

File : `backend/app/services/auth/verification.py` : Before creating a new verification session, we now explicitly clean expired tokens from Supabase using `await cleanup_expired_tokens()`, in `create_verification_session()` function.

CHANGE 2 : Make `/verify_github` expiry-aware

File : `backend/integrations/discord/cogs.py` : Token expiry is checked before showing “Verification Pending”


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verification token expiration handling improved to avoid unnecessary re-verification prompts.
  * Expired tokens are now proactively cleaned up before new sessions are created.
  * All timestamps and expiry comparisons are now timezone-aware (UTC), fixing inconsistent expiry and time-remaining calculations.
  * Discord verification flow refined to better respect token state and existing pending verifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->