### PR TITLE
Fix : Repo Indexing Stuck in Pending State (#228)

### DIFF
--- a/backend/app/services/auth/verification.py
+++ b/backend/app/services/auth/verification.py
@@ -36,6 +36,7 @@ async def create_verification_session(discord_id: str) -> Optional[str]:
     """
     supabase = get_supabase_client()
 
+    await cleanup_expired_tokens()
     _cleanup_expired_sessions()
 
     token = str(uuid.uuid4())

--- a/backend/app/services/codegraph/repo_service.py
+++ b/backend/app/services/codegraph/repo_service.py
@@ -68,22 +68,21 @@ class RepoService:
                         "status": "error",
                         "message": f"Repository already indexed. Graph: `{repo_data['graph_name']}`"
                     }
-                elif status == 'pending':
-                    return {
-                        "status": "error",
-                        "message": "Repository indexing in progress. Please wait."
-                    }
-                # If failed, we'll allow re-indexing by updating the existing record
+                
+                # if status is pending or faild --> restart indexing
+                logger.info(
+                    f"Restarting indexing for {repo_info['full_name']} "
+                    f"(previous status: {status})"
+                )
 
-                # Update existing failed record
-                logger.info(f"Updating existing failed record for {repo_info['full_name']}")
+                logger.info(f"Updating existing record for {repo_info['full_name']}") 
                 await self.supabase.table("indexed_repositories").update({
                     "indexing_status": "pending",
                     "last_error": None,
                     "updated_at": datetime.now().isoformat()
                 }).eq("id", repo_data['id']).execute()
             else:
-                # Insert new record
+                # Insert new record (new repository)
                 logger.info(f"Creating new record for {repo_info['full_name']}")
                 await self.supabase.table("indexed_repositories").insert({
                     "repository_full_name": repo_info['full_name'],

--- a/backend/app/services/codegraph/repo_service.py
+++ b/backend/app/services/codegraph/repo_service.py
@@ -69,7 +69,7 @@ class RepoService:
                         "message": f"Repository already indexed. Graph: `{repo_data['graph_name']}`"
                     }
                 
-                # if status is pending or faild --> restart indexing
+                # if status is pending or failed --> restart indexing
                 logger.info(
                     f"Restarting indexing for {repo_info['full_name']} "
                     f"(previous status: {status})"

--- a/backend/integrations/discord/cogs.py
+++ b/backend/integrations/discord/cogs.py
@@ -218,7 +218,8 @@ class DevRelCommands(commands.Cog):
                 title="🔄 Indexing Repository",
                 description=(
                     f"Indexing `{repository}`...\n\n"
-                    "This typically takes 5-30 minutes depending on repository size."
+                    "⏳ Note: For large repositories, indexing can take 30-35 minutes."
+                    "Please wait until the process completes."
                 ),
                 color=discord.Color.blue()
             )
@@ -271,7 +272,7 @@ class DevRelCommands(commands.Cog):
                         error_msg = result.get("message", "Unknown error")
                         error_embed = discord.Embed(
                             title="❌ Indexing Failed",
-                            description=f"Could not index `{repository}`",
+                            description=f"Indexing did not complete `{repository}`",
                             color=discord.Color.red()
                         )
                         error_embed.add_field(
@@ -283,8 +284,6 @@ class DevRelCommands(commands.Cog):
                         tip = None
                         if "already indexed" in error_msg.lower():
                             tip = "This repository is already indexed! You can query it directly."
-                        elif "pending" in error_msg.lower():
-                            tip = "Indexing is in progress. Check status with `/list_indexed_repos`"
 
                         if tip:
                             error_embed.add_field(

--- a/backend/integrations/discord/cogs.py
+++ b/backend/integrations/discord/cogs.py
@@ -147,6 +147,10 @@ class DevRelCommands(commands.Cog):
                     if expires_at_dt < now_utc:
                         is_expired = True
 
+                else:
+                    #  token exists but no expiry → treat as expired
+                    is_expired = True
+
                 if not is_expired:
                     embed = discord.Embed(
                         title="⏳ Verification Pending",

--- a/backend/integrations/discord/cogs.py
+++ b/backend/integrations/discord/cogs.py
@@ -3,6 +3,7 @@ import asyncio
 import discord
 from discord import app_commands
 from discord.ext import commands, tasks
+from datetime import datetime, timezone
 
 from app.agents.devrel.onboarding.messages import (
     build_encourage_verification_message,
@@ -129,18 +130,36 @@ class DevRelCommands(commands.Cog):
                 return
 
             if user_profile.verification_token:
-                embed = discord.Embed(
-                    title="⏳ Verification Pending",
-                    description="You already have a verification in progress.",
-                    color=discord.Color.orange()
-                )
-                embed.add_field(
-                    name="What to do",
-                    value="Please complete the existing verification or wait for it to expire (5 minutes).",
-                    inline=False
-                )
-                await interaction.followup.send(embed=embed, ephemeral=True)
-                return
+                expires_at = user_profile.verification_token_expires_at
+                is_expired = False
+
+                if expires_at:
+                    if isinstance(expires_at, str):
+                        expires_at_dt = datetime.fromisoformat(expires_at)
+                    else:
+                        expires_at_dt = expires_at  
+
+                    if expires_at_dt.tzinfo is None:
+                        expires_at_dt = expires_at_dt.replace(tzinfo=timezone.utc)
+                    
+                    now_utc = datetime.now(timezone.utc)
+
+                    if expires_at_dt < now_utc:
+                        is_expired = True
+
+                if not is_expired:
+                    embed = discord.Embed(
+                        title="⏳ Verification Pending",
+                        description="You already have a verification in progress.",
+                        color=discord.Color.orange()
+                    )
+                    embed.add_field(
+                        name="What to do",
+                        value="Please complete the existing verification or wait for it to expire (5 minutes).",
+                        inline=False
+                    )
+                    await interaction.followup.send(embed=embed, ephemeral=True)
+                    return
 
             session_id = await create_verification_session(str(interaction.user.id))
             if not session_id:

--- a/backend/integrations/discord/cogs.py
+++ b/backend/integrations/discord/cogs.py
@@ -218,7 +218,7 @@ class DevRelCommands(commands.Cog):
                 title="🔄 Indexing Repository",
                 description=(
                     f"Indexing `{repository}`...\n\n"
-                    "⏳ Note: For large repositories, indexing can take 30-35 minutes."
+                    "⏳ Note: For large repositories, indexing can take 30-35 minutes.\n" 
                     "Please wait until the process completes."
                 ),
                 color=discord.Color.blue()


### PR DESCRIPTION
Closes #228 


## 📝 Description

This PR improves the repository indexing flow to prevent repositories from getting stuck indefinitely in a pending state and allows safe recovery from failures or backend crashes.
The change ensures that indexing can always be retried unless a repository has already been successfully indexed.

## 🔧 Problem Solved

Previously, repositories could remain stuck in pending state if :

- The code-graph backend crashed, 
- The network dropped mid-request, or
- or no response was returned from `/analyze_repo`.

In such cases, subsequent `/index_repository` requests would only show “indexing in progress” and never restart indexing, leaving users blocked.

## 🔧 Solution

The indexing flow is updated to treat pending and failed states as recoverable, while keeping completed as a terminal state.
Key changes made :

completed --> indexing is blocked (no re-index)
failed --> indexing is restarted
pending --> indexing is restarted (covers slow jobs and backend crashes)

User is clearly informed that indexing may take 30–35 minutes.

## FINAL INDEXING FLOW :

#### Case 1: New repository (never indexed before) :

- User runs `/index_repository`
- Discord immediately shows : “Indexing started. This can take 30–35 minutes.”
- Backend creates a new DB row with `status = pending.`
- Backend calls `/analyze_repo`
   If indexing succeeds :
        DB --> `status = completed` , user sees “Repository Indexed”.
   If indexing fails : 
        DB --> `status = failed` , user sees “Indexing Failed”.


#### Case 2: Repository already indexed (completed)

-  User runs `/index_repository`.
- Backend checks DB.
- Status is completed.
- User sees : “Repository already indexed”.


#### Case 3: Repository in failed state

- User runs `/index_repository`.
- Backend finds `status = failed`.
- Backend resets : `status = pending` , `last_error = null`.
- `/analyze_repo` is called again and user sees “Indexing started again. This can take 30–35 minutes.”


#### Case 4: Repository in pending state (including backend crash)

- User runs `/index_repository`.
- Backend finds `status = pending`
   This could mean : Indexing is slow OR backend crashed earlier.
- Backend resets and restarts indexing
User sees : “Indexing started again. Please wait 30–35 minutes.”


### ✅ Checklist

- [x] I have read the contributing guidelines.
- [  ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added necessary documentation (if applicable).
- [x] Any dependent changes have been merged and published in downstream modules.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clean up expired verification tokens before creating new verification sessions.
  * Allow pending or failed repository indexing to be restarted instead of returned as an error.

* **Improvements**
  * Preserve “verification pending” prompts for still-valid tokens with timezone-aware expiry checks.
  * Clarified indexing messages: updated failure wording and added expected duration guidance (~30–35 minutes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->