### PR TITLE
Fix EmbeddingService blocking event loop by offloading encode to thread

### DIFF
--- a/backend/app/services/embedding_service/service.py
+++ b/backend/app/services/embedding_service/service.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 import config
 from typing import List, Dict, Any, Optional
@@ -66,6 +67,10 @@ class EmbeddingService:
                 raise
         return self._llm
 
+
+    def _encode_sync(self, *args, **kwargs):
+        return self.model.encode(*args, **kwargs)
+
     async def get_embedding(self, text: str) -> List[float]:
         """Generate embedding for a single text input"""
         try:
@@ -74,11 +79,13 @@ class EmbeddingService:
                 text = [text]
 
             # Generate embeddings
-            embeddings = self.model.encode(
+            embeddings = await asyncio.to_thread(
+                self._encode_sync,
                 text,
                 convert_to_tensor=True,
                 show_progress_bar=False
             )
+
 
             # Convert to standard Python list and return
             embedding_list = embeddings[0].cpu().tolist()
@@ -92,12 +99,14 @@ class EmbeddingService:
         """Generate embeddings for multiple text inputs in batches"""
         try:
             # Generate embeddings
-            embeddings = self.model.encode(
+            embeddings = await asyncio.to_thread(
+                self._encode_sync,
                 texts,
                 convert_to_tensor=True,
                 batch_size=MAX_BATCH_SIZE,
                 show_progress_bar=len(texts) > 10
             )
+
 
             # Convert to standard Python list
             embedding_list = embeddings.cpu().tolist()


### PR DESCRIPTION
Fixes #261 
Problem:
EmbeddingService.get_embedding() and get_embeddings() call SentenceTransformer.encode() inside async methods.
Since encode() is synchronous and CPU-heavy, it blocks the asyncio event loop and prevents concurrent requests.

Solution:
Moved encode calls to asyncio.to_thread() using a small synchronous helper method.

Result:
Embedding generation no longer blocks the event loop.
Improves concurrency without changing public API or behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and responsiveness of the embedding service for both single and batch embedding operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->